### PR TITLE
Support for multiple users, or bulk users

### DIFF
--- a/haiku_node/babel/cli.py
+++ b/haiku_node/babel/cli.py
@@ -1,13 +1,11 @@
 import logging
-
-import click
-
-from eosapi import Client
-
 from itertools import product
 
+import click
+from eosapi import Client
+
 from haiku_node.blockchain.acl import UnificationACL
-from haiku_node.config.config import registered_apps, UnificationConfig
+from haiku_node.config.config import UnificationConfig
 from haiku_node.eosio_helpers.accounts import AccountManager
 from haiku_node.validation.validation import UnificationAppScValidation
 
@@ -34,7 +32,8 @@ def permissions(user):
     eos_client = Client(
         nodes=[f"http://{conf['eos_rpc_ip']}:{conf['eos_rpc_port']}"])
 
-    for requester, provider in product(registered_apps, registered_apps):
+    apps = conf.registered_apps
+    for requester, provider in product(apps, apps):
         if requester == provider:
             continue
         v = UnificationAppScValidation(

--- a/haiku_node/client.py
+++ b/haiku_node/client.py
@@ -38,7 +38,7 @@ class HaikuDataClient:
         # TODO: Convert to a particular request body
         """
         return {
-            'user': user,
+            'users': [user],
             'data_id': request_hash
         }
 
@@ -69,8 +69,10 @@ class HaikuDataClient:
         r = requests.post(f"{base}/data_request", json=payload, verify=False)
         d = r.json()
 
-        if r.status_code != 200:
+        if r.status_code == 401:
             raise Unauthorized(d['message'])
+        if r.status_code != 200:
+            raise Exception(d['message'])
 
         # Now verify the response
         encrypted_body = d['body']

--- a/haiku_node/config/config.py
+++ b/haiku_node/config/config.py
@@ -7,13 +7,14 @@ import logging
 log = logging.getLogger(__name__)
 
 
-# The registered apps should exist in a database, or come from the demo config
-registered_apps = ['app1', 'app2', 'app3']
-
-
 class UnificationConfig:
-
     config_path = '/config/config.json'
+
+    # Babel needs registered apps to render what the user permissions are
+    registered_apps = ['app1', 'app2', 'app3']
+
+    # Haiku server needs registered users to support bulk ingestion
+    registered_users = ['user1', 'user2', 'user3']
 
     def __init__(self):
         with open(self.parent_directory() + self.config_path) as f:

--- a/test/systemtest.py
+++ b/test/systemtest.py
@@ -52,7 +52,7 @@ def systest_auth(requesting_app, providing_app, user):
 
     base = base_url('https', f"haiku-{providing_app}", 8050)
     body = {
-        'user': user,
+        'users': [user],
         'data_id': 'data-request'
     }
 


### PR DESCRIPTION
We can fetch data for multiple users, or all that have provisioned, if
none are specified. CLI support currently only exists for one user,
but can be extended.